### PR TITLE
Fix packages in INSTALL for Ubuntu 20.04

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -6,10 +6,8 @@ sudo apt-get install build-essential
 sudo apt-get install libfontconfig1
 sudo apt-get install mesa-common-dev
 sudo apt-get install libglu1-mesa-dev
-sudo apt install libpcap libpcap-dev
 sudo apt install libpcap-dev
 sudo apt install libqwt-qt5-dev
-sudo apt install libsvg-qt5-dev
 sudo apt-get install libqt5svg5*
 sudo apt-get install qttools5-*
 


### PR DESCRIPTION
libpcap-dev package is redundant.
libpcap and libsvg-qt5-dev packages don't exist.

Signed-off-by: Chandan Kumar <chandansbg@gmail.com>